### PR TITLE
Chore: update GitHub Actions to use latest versions of checkout, setup-node, and upload-artifact.

### DIFF
--- a/.github/workflows/frontend-ci-cd.yml
+++ b/.github/workflows/frontend-ci-cd.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'npm'
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload build artifact
         if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: dist/


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration for the frontend CI/CD pipeline. The changes primarily involve upgrading the versions of various actions used in the workflow.

Version upgrades in `.github/workflows/frontend-ci-cd.yml`:

* Updated `actions/checkout` from version 3 to version 4.
* Updated `actions/setup-node` from version 3 to version 4.
* Updated `actions/upload-artifact` from version 3 to version 4.