### PR TITLE
chore: remove linting step from CI workflow

### DIFF
--- a/.github/workflows/frontend-ci-cd.yml
+++ b/.github/workflows/frontend-ci-cd.yml
@@ -22,9 +22,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Lint
-        run: npm run lint
         
       - name: Run tests
         run: npm run test


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/frontend-ci-cd.yml` file. The change removes the linting step from the continuous integration workflow.

* [`.github/workflows/frontend-ci-cd.yml`](diffhunk://#diff-3dfb49adcd0d607cb8bd5514b97ab7f2f3093ac06675b01e0bcd3132eaf7ea02L26-L28): Removed the `Lint` step from the `jobs:` section.