### PR TITLE
Chore: remove unused screenshot entries from manifest.json

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,4 +1,3 @@
-
 {
   "name": "Tomato Expert",
   "short_name": "Tomato Expert",
@@ -9,22 +8,6 @@
   "background_color": "#F2FCE2",
   "theme_color": "#e63946",
   "categories": ["agriculture", "productivity", "utility"],
-  "screenshots": [
-    {
-      "src": "/screenshots/dashboard.png",
-      "sizes": "1280x720",
-      "type": "image/png",
-      "platform": "wide",
-      "label": "Dashboard"
-    },
-    {
-      "src": "/screenshots/diagnosis.png",
-      "sizes": "1280x720",
-      "type": "image/png",
-      "platform": "wide",
-      "label": "Plant Diagnosis"
-    }
-  ],
   "icons": [
     {
       "src": "/favicon.ico",


### PR DESCRIPTION
This pull request includes changes to the `public/manifest.json` file to simplify the manifest by removing unused screenshot entries.

Manifest simplification:

* [`public/manifest.json`](diffhunk://#diff-639916bc14c3f311c31f629a2ec116292a4b2f64d06b3607b9ddd2e495703895L12-L27): Removed the `screenshots` array, which included entries for the dashboard and plant diagnosis screenshots.