### PR TITLE
Fix: Remove '/api' prefix from farm location API endpoints for consistency

### DIFF
--- a/src/components/map/UgandaBlightMap.tsx
+++ b/src/components/map/UgandaBlightMap.tsx
@@ -75,8 +75,8 @@ const UgandaBlightMap: React.FC = () => {
         // Use public endpoint if on landing page or not authenticated
         const endpoint =
           isLandingPage || !isAuthenticated
-            ? "/api/map/public-farm-locations" // Add /api prefix
-            : "/api/map/farm-locations"; // Add /api prefix
+            ? "/map/public-farm-locations"
+            : "/map/farm-locations";
 
         // Handle potential errors for public access
         try {


### PR DESCRIPTION
This pull request makes a small adjustment to the API endpoint paths in the `UgandaBlightMap` component to remove the `/api` prefix.

* [`src/components/map/UgandaBlightMap.tsx`](diffhunk://#diff-5194d1c2230866abbfbec43e73bb36c7dcd447ab3a1abf271e0076e0c5150ab3L78-R79): Updated the endpoint paths for public and authenticated farm locations by removing the `/api` prefix.