### PR TITLE
Fix: Remove '/api' prefix from public farm locations API endpoint for consistency

### DIFF
--- a/src/components/map/UgandaBlightMap.tsx
+++ b/src/components/map/UgandaBlightMap.tsx
@@ -75,8 +75,8 @@ const UgandaBlightMap: React.FC = () => {
         // Use public endpoint if on landing page or not authenticated
         const endpoint =
           isLandingPage || !isAuthenticated
-            ? "/api/map/public-farm-locations" // Add /api prefix
-            : "/api/map/farm-locations"; // Add /api prefix
+            ? "/map/public-farm-locations"
+            : "/map/farm-locations";
 
         // Handle potential errors for public access
         try {

--- a/src/components/map/UgandaBlightMap.tsx
+++ b/src/components/map/UgandaBlightMap.tsx
@@ -142,7 +142,7 @@ const UgandaBlightMap: React.FC = () => {
             // If authenticated endpoint fails with auth error, try public endpoint
             try {
               const publicResponse = await api.get(
-                "/api/map/public-farm-locations"
+                "/map/public-farm-locations"
               );
               setFarmLocations(publicResponse.data.locations);
 


### PR DESCRIPTION
This pull request includes a small change to the `UgandaBlightMap` component. The change updates the API endpoint path used in the `publicResponse` call by removing the `/api` prefix.