### PR TITLE
Fix: Refactor VAPID public key assignment to use let for potential reassignment

### DIFF
--- a/src/services/pushNotificationService.ts
+++ b/src/services/pushNotificationService.ts
@@ -139,8 +139,8 @@ export const subscribeToPushNotifications = async () => {
     
     // Get server's public key
     const response = await api.get('/notifications/vapid-key');
-    const vapidPublicKey = response.data.publicKey;
-    
+    let vapidPublicKey = response.data.publicKey;
+
     if (!vapidPublicKey) {
       console.error('No VAPID public key available');
       return false;


### PR DESCRIPTION
This pull request includes a minor change in the `subscribeToPushNotifications` function within the `src/services/pushNotificationService.ts` file. The change updates the declaration of the `vapidPublicKey` variable from `const` to `let` to allow for potential reassignment in the future.